### PR TITLE
Strip zero-width space chars from submitted code

### DIFF
--- a/src/Bots/CodeConversationsBot.cs
+++ b/src/Bots/CodeConversationsBot.cs
@@ -280,7 +280,7 @@ namespace CodeConversations.Bots
         {
             var matches = Regex.Matches(messageText, regularExpression, RegexOptions.Singleline);
             var result = matches.First().Groups[2].Value;
-            return result;
+            return result.Replace("\u200B", "");
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/markpitop/dotnet-demo/issues/5
`Unexpected character ''` in error messages is Unicode Character 'ZERO WIDTH SPACE' (U+200B)

Would be good to look at this with Brady, as he may understand the underlying problem and know of other related issues we could have